### PR TITLE
Fix requests failing issue & little improvment

### DIFF
--- a/src/components/devtools/field-rendering/relational-field-renderer.tsx
+++ b/src/components/devtools/field-rendering/relational-field-renderer.tsx
@@ -5,8 +5,10 @@ import {
     ChevronRight,
     Crosshair,
     Layers2,
+    TriangleAlert,
 } from "lucide-preact"
 import { FieldMetadataTooltip } from "@/components/devtools/field-metadata-tooltip/field-metadata-tooltip"
+import { useModelExcludedFields } from "@/components/devtools/hooks/use-model-excluded-fields"
 import { useRecordActions } from "@/components/devtools/hooks/use-record-actions"
 import { RecordRenderer } from "@/components/devtools/record-renderer"
 import { odooRpcService } from "@/services/odoo-rpc-service"
@@ -25,6 +27,7 @@ export const RelationalFieldRenderer = ({
     onContextMenu,
     level = 0,
 }: RelationalFieldProps) => {
+    const { hasModelExcludedFields, getModelExcludedFields } = useModelExcludedFields()
     const { openRecord, focusOnRecord, openRecords, focusOnRecords } =
         useRecordActions()
 
@@ -40,6 +43,9 @@ export const RelationalFieldRenderer = ({
 
     const ids = extractIds(value)
     const modelName = getRelatedModel(fieldMetadata)
+
+    const modelHasExcludedFields = modelName ? hasModelExcludedFields(modelName) : false
+    const excludedFields = modelName ? getModelExcludedFields(modelName) : []
 
     const handleExpand = async () => {
         if (!isExpanded.value && !relatedData.value) {
@@ -181,8 +187,16 @@ export const RelationalFieldRenderer = ({
                                         record.display_name ||
                                         `Record ${index + 1}`}
                                 </span>
-                                {recordId && modelName && (
+                                {(recordId && modelName) ? (
                                     <div className="record-actions">
+                                        {modelHasExcludedFields && isExpanded ? (
+                                            <span
+                                                className="excluded-fields-indicator"
+                                                title={`Excluded fields from ${modelName}: ${excludedFields.join(', ')}`}
+                                            >
+                                                <TriangleAlert size={16} />
+                                            </span>
+                                        ) : null}
                                         <button
                                             className="open-record-button focus-button"
                                             title="Focus on this record"
@@ -222,7 +236,7 @@ export const RelationalFieldRenderer = ({
                                             <Layers2 size={16} />
                                         </button>
                                     </div>
-                                )}
+                                ) : null}
                             </div>
                             {isExpanded && (
                                 <div className="relational-record-content">
@@ -298,6 +312,14 @@ export const RelationalFieldRenderer = ({
                 </span>
                 {modelName && ids.length > 0 && (
                     <div className="relational-field-actions">
+                        {modelHasExcludedFields && isExpanded.value ? (
+                            <span
+                                className="excluded-fields-indicator"
+                                title={`Excluded fields from ${modelName}: ${excludedFields.join(', ')}`}
+                            >
+                                <TriangleAlert size={12} />
+                            </span>
+                        ) : null}
                         <button
                             className="open-relational-field-button focus-button"
                             title="Focus on this record"

--- a/src/components/devtools/field-rendering/relational-field-renderer.tsx
+++ b/src/components/devtools/field-rendering/relational-field-renderer.tsx
@@ -7,9 +7,11 @@ import {
     Layers2,
     TriangleAlert,
 } from "lucide-preact"
+import { ContextMenu } from "@/components/devtools/context-menu/context-menu"
 import { FieldMetadataTooltip } from "@/components/devtools/field-metadata-tooltip/field-metadata-tooltip"
 import { useModelExcludedFields } from "@/components/devtools/hooks/use-model-excluded-fields"
 import { useRecordActions } from "@/components/devtools/hooks/use-record-actions"
+import { useRecordContextMenu } from "@/components/devtools/hooks/use-record-context-menu"
 import { RecordRenderer } from "@/components/devtools/record-renderer"
 import { odooRpcService } from "@/services/odoo-rpc-service"
 import { FieldMetadata } from "@/types"
@@ -30,6 +32,12 @@ export const RelationalFieldRenderer = ({
     const { hasModelExcludedFields, getModelExcludedFields } = useModelExcludedFields()
     const { openRecord, focusOnRecord, openRecords, focusOnRecords } =
         useRecordActions()
+    const {
+        contextMenu,
+        handleRecordContextMenu,
+        closeContextMenu,
+        getContextMenuItems,
+    } = useRecordContextMenu()
 
     const isExpanded = useSignal(false)
     const relatedData = useSignal<Record<string, unknown>[] | null>(null)
@@ -169,6 +177,13 @@ export const RelationalFieldRenderer = ({
                             <div
                                 className="relational-record-header"
                                 onClick={() => handleRelatedRecordToggle(index)}
+                                onContextMenu={(e) =>
+                                    handleRecordContextMenu(
+                                        e as unknown as MouseEvent,
+                                        record,
+                                        modelName || undefined
+                                    )
+                                }
                             >
                                 <span className="expand-icon">
                                     {isExpanded ? (
@@ -363,6 +378,13 @@ export const RelationalFieldRenderer = ({
                     {renderRelationalContent()}
                 </div>
             )}
+
+            <ContextMenu
+                visible={contextMenu.visible}
+                position={contextMenu.position}
+                items={getContextMenuItems()}
+                onClose={closeContextMenu}
+            />
         </div>
     )
 }

--- a/src/components/devtools/hooks/use-model-excluded-fields.ts
+++ b/src/components/devtools/hooks/use-model-excluded-fields.ts
@@ -1,0 +1,18 @@
+import { odooRpcService } from "@/services/odoo-rpc-service"
+
+export const useModelExcludedFields = () => {
+    const hasModelExcludedFields = (modelName: string): boolean => {
+        const config = odooRpcService.getExcludedFieldsConfig()
+        return modelName in config && config[modelName].length > 0
+    }
+
+    const getModelExcludedFields = (modelName: string): string[] => {
+        const config = odooRpcService.getExcludedFieldsConfig()
+        return config[modelName] || []
+    }
+
+    return {
+        hasModelExcludedFields,
+        getModelExcludedFields,
+    }
+}

--- a/src/components/devtools/record-renderer.tsx
+++ b/src/components/devtools/record-renderer.tsx
@@ -4,12 +4,14 @@ import {
     ChevronRight,
     Crosshair,
     Layers2,
+    TriangleAlert,
 } from "lucide-preact"
 import { useRpcQuery } from "@/contexts/devtools-signals-hook"
 import { FieldMetadata } from "@/types"
 import { ContextMenu } from "./context-menu/context-menu"
 import { RecordFieldRenderer } from "./field-rendering/record-field-renderer"
 import { useExpansion } from "./hooks/use-expansion"
+import { useModelExcludedFields } from "./hooks/use-model-excluded-fields"
 import { useRecordActions } from "./hooks/use-record-actions"
 import { useRecordContextMenu } from "./hooks/use-record-context-menu"
 import { LevelProvider } from "./level-context"
@@ -38,6 +40,7 @@ export const RecordRenderer = ({
     renderAsList = true,
 }: RecordRendererProps) => {
     const { query: rpcQuery } = useRpcQuery()
+    const { hasModelExcludedFields, getModelExcludedFields } = useModelExcludedFields()
     const { currentExpanded, toggleExpansion } = useExpansion(
         onExpandToggle,
         expandedRecords
@@ -131,6 +134,10 @@ export const RecordRenderer = ({
 
                 const displayName = getRecordDisplayName(record)
 
+                const currentModel = parentModel || rpcQuery.model
+                const modelHasExcludedFields = currentModel ? hasModelExcludedFields(currentModel) : false
+                const excludedFields = currentModel ? getModelExcludedFields(currentModel) : []
+
                 return (
                     <div
                         key={recordId}
@@ -178,49 +185,56 @@ export const RecordRenderer = ({
                                 >
                                     {displayName}
                                 </span>
-                                {(parentModel || rpcQuery.model) &&
-                                    recordId && (
-                                        <div className="record-actions">
-                                            <button
-                                                className="open-record-button focus-button"
-                                                title="Focus on this record"
-                                                onClick={(e) =>
-                                                    handleFocusRecord(
-                                                        record,
-                                                        e as unknown as Event
-                                                    )
-                                                }
+                                {(currentModel && recordId) ? (
+                                    <div className="record-actions">
+                                        {modelHasExcludedFields && isExpanded ? (
+                                            <span
+                                                className="excluded-fields-indicator"
+                                                title={`Excluded fields from ${currentModel}: ${excludedFields.join(', ')}`}
                                             >
-                                                <Crosshair size={16} />
-                                            </button>
-                                            <button
-                                                className="open-record-button"
-                                                title="Open record in Odoo"
-                                                onClick={(e) =>
-                                                    handleOpenRecord(
-                                                        record,
-                                                        e as unknown as Event,
-                                                        false
-                                                    )
-                                                }
-                                            >
-                                                <ArrowUpRight size={16} />
-                                            </button>
-                                            <button
-                                                className="open-record-button popup-button"
-                                                title="Open record in popup"
-                                                onClick={(e) =>
-                                                    handleOpenRecord(
-                                                        record,
-                                                        e as unknown as Event,
-                                                        true
-                                                    )
-                                                }
-                                            >
-                                                <Layers2 size={16} />
-                                            </button>
-                                        </div>
-                                    )}
+                                                <TriangleAlert size={16} />
+                                            </span>
+                                        ) : null}
+                                        <button
+                                            className="open-record-button focus-button"
+                                            title="Focus on this record"
+                                            onClick={(e) =>
+                                                handleFocusRecord(
+                                                    record,
+                                                    e as unknown as Event
+                                                )
+                                            }
+                                        >
+                                            <Crosshair size={16} />
+                                        </button>
+                                        <button
+                                            className="open-record-button"
+                                            title="Open record in Odoo"
+                                            onClick={(e) =>
+                                                handleOpenRecord(
+                                                    record,
+                                                    e as unknown as Event,
+                                                    false
+                                                )
+                                            }
+                                        >
+                                            <ArrowUpRight size={16} />
+                                        </button>
+                                        <button
+                                            className="open-record-button popup-button"
+                                            title="Open record in popup"
+                                            onClick={(e) =>
+                                                handleOpenRecord(
+                                                    record,
+                                                    e as unknown as Event,
+                                                    true
+                                                )
+                                            }
+                                        >
+                                            <Layers2 size={16} />
+                                        </button>
+                                    </div>
+                                ) : null}
                             </div>
                         </div>
 

--- a/src/components/devtools/selects/field-select.tsx
+++ b/src/components/devtools/selects/field-select.tsx
@@ -27,10 +27,17 @@ export const FieldSelect = ({
         }))
     })
 
-    const currentValues = Array.isArray(values) ? values : (values ? [values] : [])
+    const currentValues = Array.isArray(values)
+        ? values
+        : values
+            ? [values]
+            : []
+    const excludedFields = rpcResult.excludedFields || []
 
     const handleChange = (selectedValues: string | string[]) => {
-        const fieldsArray = Array.isArray(selectedValues) ? selectedValues : [selectedValues]
+        const fieldsArray = Array.isArray(selectedValues)
+            ? selectedValues
+            : [selectedValues]
         setRpcQuery({
             selectedFields: fieldsArray,
             offset: 0,
@@ -50,6 +57,7 @@ export const FieldSelect = ({
             enableSmartSort={true}
             maxDisplayedOptions={100}
             multiple={true}
+            excludedFields={excludedFields}
         />
     )
 }

--- a/src/components/devtools/selects/generic-select.tsx
+++ b/src/components/devtools/selects/generic-select.tsx
@@ -34,6 +34,8 @@ export interface GenericSelectProps {
         options: GenericSelectOption[],
         searchTerm: string
     ) => GenericSelectOption[]
+
+    excludedFields?: string[]
 }
 
 export const GenericSelect = ({
@@ -52,6 +54,7 @@ export const GenericSelect = ({
     enableSmartSort = true,
     customSort,
     multiple = false,
+    excludedFields = [],
 }: GenericSelectProps) => {
     const searchValue = useSignal("")
     const isOpen = useSignal(false)
@@ -294,6 +297,7 @@ export const GenericSelect = ({
                 <SelectedFieldBadges
                     selectedValues={getCurrentValues()}
                     onRemove={handleRemoveBadge}
+                    excludedFields={excludedFields}
                 />
             )}
 

--- a/src/components/devtools/selects/selected-field-badges.tsx
+++ b/src/components/devtools/selects/selected-field-badges.tsx
@@ -1,50 +1,59 @@
-import { X } from "lucide-preact"
+import { TriangleAlert, X } from "lucide-preact"
 import "./selects.styles.scss"
 
 interface SelectedFieldBadgesProps {
     selectedValues: string[]
     onRemove: (value: string) => void
     className?: string
+    excludedFields?: string[]
 }
 
 export const SelectedFieldBadges = ({
     selectedValues,
     onRemove,
     className = "",
+    excludedFields = [],
 }: SelectedFieldBadgesProps) => {
     if (selectedValues.length === 0) return null
 
     return (
         <div className={`selected-fields ${className}`}>
-            {selectedValues.map((selectedValue) => (
-                <div
-                    key={selectedValue}
-                    className="selected-field"
-                    onMouseDown={(e) => {
-                        if (e.button === 1) {
-                            e.preventDefault()
-                            e.stopPropagation()
-                            onRemove(selectedValue)
-                        }
-                    }}
-                    title="Middle-click to remove"
-                >
-                    <span className="field-name">
-                        {selectedValue}
-                    </span>
-                    <button
-                        type="button"
-                        className="remove-field"
-                        onClick={(e) => {
-                            e.stopPropagation()
-                            onRemove(selectedValue)
+            {selectedValues.map((selectedValue) => {
+                const isExcluded = excludedFields.includes(selectedValue)
+                return (
+                    <div
+                        key={selectedValue}
+                        className={`selected-field ${isExcluded ? 'excluded' : ''}`}
+                        onMouseDown={(e) => {
+                            if (e.button === 1) {
+                                e.preventDefault()
+                                e.stopPropagation()
+                                onRemove(selectedValue)
+                            }
                         }}
-                        aria-label={`Remove ${selectedValue}`}
+                        title={isExcluded
+                            ? `${selectedValue} - This field was excluded from the result due to compatibility issues. Middle-click to remove.`
+                            : "Middle-click to remove"
+                        }
                     >
-                        <X size={12} />
-                    </button>
-                </div>
-            ))}
+                        <span className="field-name">
+                            {isExcluded && <TriangleAlert size={12} className="excluded-indicator" />}
+                            {selectedValue}
+                        </span>
+                        <button
+                            type="button"
+                            className="remove-field"
+                            onClick={(e) => {
+                                e.stopPropagation()
+                                onRemove(selectedValue)
+                            }}
+                            aria-label={`Remove ${selectedValue}`}
+                        >
+                            <X size={12} />
+                        </button>
+                    </div>
+                )
+            })}
         </div>
     )
 }

--- a/src/components/devtools/selects/selects.styles.scss
+++ b/src/components/devtools/selects/selects.styles.scss
@@ -19,6 +19,9 @@
     gap: 6px;
 
     .field-name {
+        display: flex;
+        align-items: center;
+        gap: 6px;
         font-weight: 500;
         user-select: none;
     }
@@ -35,6 +38,14 @@
 
         &:hover {
             opacity: 0.7;
+        }
+    }
+
+    &.excluded {
+        background-color: #e67e22;
+
+        .excluded-indicator {
+            animation: pulse 2s infinite;
         }
     }
 }
@@ -193,5 +204,19 @@
 
     svg {
         animation: spin 2s linear infinite;
+    }
+}
+
+@keyframes pulse {
+    0% {
+        opacity: 1;
+    }
+
+    50% {
+        opacity: 0.5;
+    }
+
+    100% {
+        opacity: 1;
     }
 }

--- a/src/entries/devtools-panel/style.scss
+++ b/src/entries/devtools-panel/style.scss
@@ -387,6 +387,15 @@ body {
         flex-shrink: 0;
     }
 
+    .excluded-fields-indicator {
+        width: 20px;
+        height: 20px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: var(--devtools-warning);
+    }
+
     .open-relational-field-button {
         @include m.icon-button(20px, 10px, 3px);
         @include m.focus-visible(rgba-from(var(--devtools-primary), 0.10));
@@ -538,6 +547,14 @@ body {
         gap: 4px;
         margin-left: 8px;
         flex-shrink: 0;
+    }
+
+    .excluded-fields-indicator {
+        display: inline-flex;
+        align-items: center;
+        color: var(--devtools-warning);
+        margin-right: 4px;
+        font-size: 12px;
     }
 
     .open-record-button {
@@ -720,6 +737,15 @@ body {
                         gap: 4px;
                         margin-left: 8px;
                         flex-shrink: 0;
+                    }
+
+                    .excluded-fields-indicator {
+                        width: 24px;
+                        height: 24px;
+                        display: flex;
+                        align-items: center;
+                        justify-content: center;
+                        color: var(--devtools-warning);
                     }
 
                     .open-record-button {

--- a/src/types/devtools.types.ts
+++ b/src/types/devtools.types.ts
@@ -36,6 +36,7 @@ export interface RpcResultState {
     isNewQuery: boolean
     model: string | null
     fieldsMetadata?: Record<string, FieldMetadata>
+    excludedFields?: string[]
 }
 
 export interface OdooModel {

--- a/src/types/odoo.types.ts
+++ b/src/types/odoo.types.ts
@@ -1,3 +1,5 @@
+import type { FieldMetadata } from "./devtools.types"
+
 // Odoo domain types - operator can be any string, let Odoo handle validation
 export type OdooDomainOperator = string
 export type OdooDomainCondition = [string, OdooDomainOperator, unknown]
@@ -10,6 +12,7 @@ export interface OdooRpcParams {
     args?: unknown[]
     kwargs?: Record<string, unknown>
     context?: Record<string, unknown>
+    fieldsMetadata?: Record<string, FieldMetadata>
 }
 export interface OdooActionParams {
     action: Record<string, unknown> | number | string
@@ -28,6 +31,7 @@ export interface OdooSearchParams {
 
 export interface OdooSearchReadParams extends OdooSearchParams {
     ids?: number[]
+    fieldsMetadata?: Record<string, FieldMetadata>
 }
 
 export interface OdooWriteParams {


### PR DESCRIPTION
### [FIX] Requests failing issue
In some case requests were failing for, at least, these two issues :
- The Odoo response was too big for the sendMessage WebExt function.
	- No response was received in this case and we were stuck in "executing query" loop. To fix this, I just get rid of the content script usage and the rpc service. I know use the JSON RPC API. We don't have the length issue anymore but we'll have to support the new system in the future since JSON RPC will be deprecated in v19.1+

- Some fields were impossible to decode from Odoo side (e.g. `raw` on `ir.attachment`) so I've introduced some exclusions logic. Atm I've found 2 fields (1 in `ir.attachment` and 1 in `account.move`).
	- The logic is:
		- If we don't specify field in our request :
			- If the model hasn't excluded field : proceed
			- If it has : append every model's fields (except the excluded ones ofc) before the request
		- If we specify field(s) in our request :
			- Only excluded field(s) : just request the "id" field by default
			- Multiple fields : remove the excluded ones

---

### [IMP] Add context menu on relational field list 
Before that, right clicking on an element of a relational field list did'nt show the custom menu. Now it does.