### PR TITLE
[FIX] Prevent reload loop with default darkmode

### DIFF
--- a/src/components/devtools/context-menu/context-menu.style.scss
+++ b/src/components/devtools/context-menu/context-menu.style.scss
@@ -2,6 +2,7 @@
     background-color: var(--devtools-bg-secondary);
     border: 1px solid var(--devtools-border);
     border-radius: 6px;
+    overflow: hidden;
     box-shadow: var(--devtools-shadow-lg);
     min-width: 180px;
     z-index: 1000;
@@ -13,7 +14,6 @@
     color: var(--devtools-text-primary);
     cursor: pointer;
     transition: background-color 0.2s ease;
-    border-radius: 6px;
 
     &:hover {
         background-color: var(--devtools-primary);

--- a/src/features/default-dark-mode.ts
+++ b/src/features/default-dark-mode.ts
@@ -9,6 +9,7 @@ const setDefaultDarkMode = (): { reload: boolean; url?: string } => {
     if (
         !odooVersion ||
         parseFloat(odooVersion) < 16.0 ||
+        parseFloat(odooVersion) >= 19.0 ||
         defaultDarkMode === "false"
     )
         return { reload: false }


### PR DESCRIPTION
### [FIX] Prevent reload loop with default darkmode 
Now that the colorscheme is stored in the v19+ DB (https://github.com/odoo/enterprise/pull/93177), we can fall in reload loop if an user enabled darkmode by default but put light mode in Odoo.
Will have to check for a proper way to handle it