### PR TITLE
[FIX] devtools unavailable since Chromium 144

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,0 +1,4 @@
+export const browser =
+    import.meta.env.BROWSER !== "firefox"
+        ? globalThis.chrome
+        : globalThis.browser;

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -90,6 +90,12 @@ export default defineConfig({
             esbuild: {
                 minifyIdentifiers: false, // Keep variable names
             },
+            resolve: {
+                alias: {
+                    "wxt/browser": new URL("./src/browser.ts", import.meta.url)
+                        .pathname,
+                },
+            },
         };
     },
 });


### PR DESCRIPTION
Temporary fix: alias wxt/browser to src/browser

Chromium 144 update introduced an unintended breaking change. This has been fixed in Chromium, but until it is deployed, this fix must be deployed.

See:
https://issues.chromium.org/issues/475255714
https://issues.chromium.org/issues/470092691
https://issues.chromium.org/issues/474134785 (linked changes: https://chromium-review.googlesource.com/c/chromium/src/+/7423343)